### PR TITLE
Re-target to .NET 4.5

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -4,8 +4,6 @@
 #tool "OpenCover"
 #tool "nuget:?package=ReportGenerator"
 
-
-
 #load "helpers.cake"
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -14,7 +12,7 @@
 
 var target = Argument<string>("target", "Default");
 var configuration = Argument<string>("configuration", "Release");
-var framework = Argument<string>("framework", "net451,netstandard1.6");
+var framework = Argument<string>("framework", "net45,netstandard1.6");
 
 ///////////////////////////////////////////////////////////////////////////////
 // GLOBAL VARIABLES

--- a/src/Cake.Newman/project.json
+++ b/src/Cake.Newman/project.json
@@ -10,7 +10,7 @@
 		"netstandard1.6": {
 			"imports": "dnxcore50"
 		},
-		"net451": {}
+		"net45": {}
 	},
 	"buildOptions": {
 		"xmlDoc": true


### PR DESCRIPTION
Changes `net451` references to `net45`

> Published on NuGet as 0.1.0-unstable0004