### PR TITLE
Fix the runner using the correct per-platform extension 

### DIFF
--- a/src/Cake.Newman.Tests/AddinTests.cs
+++ b/src/Cake.Newman.Tests/AddinTests.cs
@@ -48,7 +48,7 @@ namespace Cake.Newman.Tests
             // When
             var result = fixture.Run();
             // Then
-            result.Path.FullPath.Should().Be("/Working/tools/newman.cmd");
+            result.Path.FullPath.Should().Be("/Working/tools/newman");
         }
 
         [Fact]

--- a/src/Cake.Newman.Tests/NewmanFixture.cs
+++ b/src/Cake.Newman.Tests/NewmanFixture.cs
@@ -9,7 +9,7 @@ namespace Cake.Newman.Tests
     {
         internal FilePath InputFile {get;set;}
 
-        public NewmanFixture () : base("newman.cmd")
+        public NewmanFixture () : base("newman")
         {
             Settings = Settings ?? new NewmanSettings();
             InputFile = "./collection.json";

--- a/src/Cake.Newman/NewmanRunner.cs
+++ b/src/Cake.Newman/NewmanRunner.cs
@@ -15,18 +15,19 @@ namespace Cake.Newman
         {
             Log = log;
             FileSystem = fileSystem;
+            Environment = environment;
         }
 
         private ICakeLog Log { get; }
         private IFileSystem FileSystem { get; }
+        private ICakeEnvironment Environment { get; }
 
         protected override string GetToolName() => "Newman";
 
         protected override IEnumerable<string> GetToolExecutableNames()
         {
+            yield return Environment.Platform.Family == PlatformFamily.Windows ? "newman.cmd" : "newman.sh";
             yield return "newman";
-            yield return "newman.cmd";
-            yield return "newman.sh";
         }
 
         internal void RunTool(FilePath collectionFile, NewmanSettings settings)


### PR DESCRIPTION
Uses the `.cmd` on Windows, `.sh` on non-Windows, and defaults to just `newman`.