### PR TITLE
Add cake contrib icon to csproj

### DIFF
--- a/src/Cake.Newman/Cake.Newman.csproj
+++ b/src/Cake.Newman/Cake.Newman.csproj
@@ -9,6 +9,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageIconUrl>https://cdn.rawgit.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</PackageIconUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added cake-contrib icon in .csproj as suggested in issue #12