### PR TITLE
Feature/updated docs about installation newman

### DIFF
--- a/src/Cake.Newman/Aliases.cs
+++ b/src/Cake.Newman/Aliases.cs
@@ -13,7 +13,12 @@ namespace Cake.Newman
     /// reference from NuGet.org:
     /// <code>
     /// #addin Cake.Newman
+    /// #addin Cake.Npm
     /// </code>
+    /// </para>
+    /// <para>
+    /// Postman needs the Newman npm package to run, or else the error 'Newman: executable not found' will be raised. You need to import
+    /// the Postman package first. To do this, create a task and import the 'Postman' npm package using <see href="https://cakebuild.net/dsl/npm/">NpmInstall</see>.
     /// </para>
     /// </summary>
     [CakeAliasCategory("Postman")]

--- a/src/Cake.Newman/Aliases.cs
+++ b/src/Cake.Newman/Aliases.cs
@@ -20,6 +20,7 @@ namespace Cake.Newman
     /// Postman needs the Newman npm package to run, or else the error 'Newman: executable not found' will be raised. You need to import
     /// the Postman package first. To do this, create a task and import the 'Postman' npm package using <see href="https://cakebuild.net/dsl/npm/">NpmInstall</see>.
     /// </para>
+    /// <para>More information can be found in the <see href="https://cake-contrib.github.io/Cake.Newman/doc/intro.html">cake-contrib docs</see></para>
     /// </summary>
     [CakeAliasCategory("Postman")]
     [CakeNamespaceImport("Cake.Newman")]


### PR DESCRIPTION
The documentation on the Cake website does not include the step 'Install Newman package'.
This is confusing for people that use Cake.Newman for the first time (or are too impatient to read or search the documentation on cake-contrib :) )