### PR TITLE
Append a quoted argument to support whitespace in the filename

### DIFF
--- a/src/Cake.Newman.Tests/AddinTests.cs
+++ b/src/Cake.Newman.Tests/AddinTests.cs
@@ -114,7 +114,7 @@ namespace Cake.Newman.Tests
             var result = fixture.Run();
 
             // Then
-            result.Args.Should().Be("run custom-collection.json", "provided file is specified");
+            result.Args.Should().Be("run \"custom-collection.json\"", "provided file is specified");
         }
     }
 }

--- a/src/Cake.Newman.Tests/TestExtensions.cs
+++ b/src/Cake.Newman.Tests/TestExtensions.cs
@@ -7,7 +7,7 @@ namespace Cake.Newman.Tests
     {
         internal static string Args(this ToolFixtureResult result)
         {
-            return result.Args.Replace("run collection.json ", string.Empty);
+            return result.Args.Replace("run \"collection.json\" ", string.Empty);
         }
 
         internal static ExceptionAssertions<T> WhereMessageContains<T>(this ExceptionAssertions<T> exception, string s) where T : System.Exception

--- a/src/Cake.Newman/NewmanRunner.cs
+++ b/src/Cake.Newman/NewmanRunner.cs
@@ -37,7 +37,7 @@ namespace Cake.Newman
             if (!FileSystem.Exist(collectionFile)) throw new FileNotFoundException(collectionFile.FullPath);
             var args = new ProcessArgumentBuilder();
             args.Append("run");
-            args.Append(collectionFile.FullPath);
+            args.AppendQuoted(collectionFile.FullPath);
             settings.Build(args);
             Log.Debug(args.Render());
             Run(settings, args);


### PR DESCRIPTION
In response to #17 

We are actively using your addin to run automated API tests generated from Open API docs, which is why we have white-space in our collection names.